### PR TITLE
Add GitHub Actions workflow for publishing Python package

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,108 @@
+name: Publish Python Package to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Only allow one publish at a time
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    # Only run on microsoft/AgentSchema repo AND only for python-v* tags
+    if: |
+      github.repository == 'microsoft/AgentSchema' && 
+      (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/python-v'))
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        working-directory: runtime/python/agentschema
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        working-directory: runtime/python/agentschema
+        run: uv run pytest tests/ -v --tb=short
+
+      - name: Run linting
+        working-directory: runtime/python/agentschema
+        run: uv run ruff check src/
+
+      - name: Validate version matches tag
+        if: github.event_name == 'release'
+        working-directory: runtime/python/agentschema
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/python-v}"
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "Tag version: $TAG_VERSION"
+          echo "Package version: $PKG_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Version mismatch! Update version in pyproject.toml to $TAG_VERSION"
+            exit 1
+          fi
+
+  build:
+    name: Build distribution
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build package
+        working-directory: runtime/python/agentschema
+        run: uv build
+
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: runtime/python/agentschema/dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish on release events (not manual workflow_dispatch)
+    if: github.event_name == 'release'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/agentschema/
+
+    permissions:
+      id-token: write # Required for trusted publishing
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses trusted publishing - no API token needed
+        # Configure at: https://pypi.org/manage/project/agentschema/settings/publishing/


### PR DESCRIPTION
**CI/CD automation for Python package publishing:**

* Introduced a `.github/workflows/publish-pypi.yml` workflow that triggers on new releases or manual dispatch, running tests, linting, version validation, and building the distribution before publishing to PyPI using trusted publishing.
* Enforced version consistency by validating that the release tag matches the version in `pyproject.toml` before publishing.
* Utilized the `uv` toolchain for Python environment setup, dependency management, and building, modernizing the Python CI pipeline.
* Configured artifact upload and download steps to pass built distributions between jobs, ensuring only tested and built artifacts are published.
* Enabled secure publishing to PyPI using OpenID Connect (OIDC) without requiring a PyPI API token, increasing security and ease of maintenance.