### PR TITLE
Update version setting in publish workflow to match release tag

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -42,19 +42,6 @@ jobs:
         working-directory: runtime/python/agentschema
         run: uv run ruff check src/
 
-      - name: Validate version matches tag
-        if: github.event_name == 'release'
-        working-directory: runtime/python/agentschema
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/python-v}"
-          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "Tag version: $TAG_VERSION"
-          echo "Package version: $PKG_VERSION"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Version mismatch! Update version in pyproject.toml to $TAG_VERSION"
-            exit 1
-          fi
-
   build:
     name: Build distribution
     needs: test
@@ -70,6 +57,15 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.12
+
+      - name: Set version from tag
+        if: github.event_name == 'release'
+        working-directory: runtime/python/agentschema
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/python-v}"
+          echo "Setting version to: $TAG_VERSION"
+          sed -i "s/^version = .*/version = \"$TAG_VERSION\"/" pyproject.toml
+          cat pyproject.toml | grep "^version"
 
       - name: Build package
         working-directory: runtime/python/agentschema


### PR DESCRIPTION
**Workflow automation improvements:**

* Removed the step that validated the version in `pyproject.toml` matches the release tag and failed the workflow on mismatch (`Validate version matches tag`).
* Added a new step that sets the version in `pyproject.toml` to match the release tag automatically when the workflow is triggered by a release event (`Set version from tag`).